### PR TITLE
Correctly lint R as supported language

### DIFF
--- a/lib/travis/yaml/nodes/language.rb
+++ b/lib/travis/yaml/nodes/language.rb
@@ -5,7 +5,7 @@ module Travis::Yaml
       default :ruby
 
       value :c, :cpp, :clojure, :d, :dart, :erlang, :go, :groovy, :haskell, :haxe, :java,
-            :node_js, :"objective-c", :ruby, :rust, :python, :perl, :php, :scala,
+            :node_js, :"objective-c", :r, :ruby, :rust, :python, :perl, :php, :scala,
             :android, :crystal, :csharp, :smalltalk
       value dartlang: :dart, jvm: :java, javascript: :node_js, node: :node_js,
             nodejs: :node_js, golang: :go, objective_c: :"objective-c",

--- a/spec/nodes/language_spec.rb
+++ b/spec/nodes/language_spec.rb
@@ -75,5 +75,13 @@ describe Travis::Yaml::Nodes::Language do
       expect(config.language)           .to be == 'node_js'
       expect(config.language.warnings)  .to include('does not support multiple values, dropping "ruby"')
     end
+
+    specify 'supports all un-aliased languages' do
+      languages = Travis::Yaml::Nodes::Language.valid_values
+      languages.each do |lang|
+        config = Travis::Yaml.parse("language: #{lang}")
+        expect(config.language).to be == lang
+      end
+    end
   end
 end


### PR DESCRIPTION
While this is officially a community-supported language, we shouldn't
warn when it is specified.

Also, add test coverage for un-aliased languages (though it's definitely possible I've simply
failed to find their current tests).

This should resolve the following issue: https://github.com/travis-ci/travis-yaml/issues/90